### PR TITLE
Recoverable errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1209,12 +1209,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1518,9 +1518,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glucmon",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -556,15 +556,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1091,6 +1091,7 @@ name = "glucmon"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "derive_more",
  "image 0.23.14",
  "reqwest",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.12.4", features = ["blocking", "json"] }
 anyhow = "1.0.82"
 image = "0.23"
 url = "2.5.2"
+derive_more = "0.99.18"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/src/commands/config_commands.rs
+++ b/src-tauri/src/commands/config_commands.rs
@@ -1,0 +1,37 @@
+use crate::{config_data::GlucmonConfigStore, Storage};
+use tauri::State;
+
+#[tauri::command]
+pub fn set_glucmon_config(
+    form_config_values: GlucmonConfigStore,
+    glucmon_config_store_mutex: State<'_, Storage>,
+    app: tauri::AppHandle,
+) -> std::result::Result<GlucmonConfigStore, String> {
+    dbg!("Setting glucmon config to state.", &form_config_values);
+    let mut state = glucmon_config_store_mutex
+        .config
+        .lock()
+        .map_err(|e| e.to_string())?;
+
+    state.update_config(
+        form_config_values.nightscout_url,
+        form_config_values.nightscout_api_token,
+        form_config_values.is_mmmol,
+    );
+
+    state.clone().save_to_disk(app).map_err(|e| e.to_string())?;
+
+    Ok(state.clone())
+}
+
+#[tauri::command]
+pub fn get_glucmon_config(
+    glucmon_config_store_mutex: State<'_, Storage>,
+) -> std::result::Result<GlucmonConfigStore, String> {
+    dbg!("Getting glucmon config from state.");
+    let state = glucmon_config_store_mutex
+        .config
+        .lock()
+        .map_err(|e| e.to_string())?;
+    Ok(state.clone())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,0 +1,3 @@
+mod config_commands;
+
+pub use config_commands::*;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -2,12 +2,21 @@ use derive_more::From;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[allow(dead_code)]
 #[derive(Debug, From)]
 pub enum Error {
     #[from]
     Custom(String),
 
     // -- Externals
+    #[from]
+    Url(url::ParseError),
+    #[from]
+    Reqwest(reqwest::Error),
+    #[from]
+    Mutex(std::sync::mpsc::RecvError),
+    #[from]
+    SerdeJson(serde_json::Error),
     #[from]
     Io(std::io::Error),
     #[from]

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,35 @@
+use derive_more::From;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, From)]
+pub enum Error {
+    #[from]
+    Custom(String),
+
+    // -- Externals
+    #[from]
+    Io(std::io::Error),
+    #[from]
+    Image(image::ImageError),
+}
+
+impl Error {
+    pub fn custom(val: impl std::fmt::Display) -> Self {
+        Self::Custom(val.to_string())
+    }
+}
+
+impl From<&str> for Error {
+    fn from(val: &str) -> Self {
+        Self::Custom(val.to_string())
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+        write!(fmt, "{self:?}")
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,11 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod config_data;
+mod error;
+mod nightscout;
+mod utils;
+
 static UPDATE_GLUCOSE_EVENT_ID: &str = "update_glucose";
 static TRAY_MENU_ITEM_GLUCOSE_ENTRY: &str = "tray_menu_item_glucose_entry";
 static TRAY_MENU_ITEM_OPEN_SETTINGS: &str = "tray_menu_item_settings";
@@ -10,104 +15,18 @@ static TRAY_MENU_ITEM_QUIT_DISPLAY: &str = "Quit Glucmon Completely";
 
 use config_data::{get_glucmon_config, set_glucmon_config, GlucmonConfigStore};
 use nightscout::{get_glucose_data, Direction};
-use std::path::PathBuf;
 use std::{sync::Mutex, thread};
 use tauri::{
-    AppHandle, CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu,
-    SystemTrayMenuItem, UserAttentionType,
+    CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem,
+    UserAttentionType,
 };
+use utils::{create_icon_from_path, get_icon_path_from_direction};
 
 #[derive(Debug)]
 struct Storage {
     config: Mutex<GlucmonConfigStore>,
 }
 
-mod config_data;
-mod nightscout;
-
-use tauri::Icon;
-
-fn create_icon_from_path(path: &PathBuf) -> Result<Icon, Box<dyn std::error::Error>> {
-    let image = image::open(path)?.to_rgba8();
-    let (width, height) = image.dimensions();
-    let resized_image = image::imageops::resize(
-        &image,
-        width / 2,
-        height / 2,
-        image::imageops::FilterType::Nearest,
-    );
-    Ok(Icon::Rgba {
-        rgba: resized_image.into_vec(),
-        width: width / 2,
-        height: height / 2,
-    })
-}
-
-fn get_icon_path_from_direction(
-    app: &AppHandle,
-    direction: &Direction,
-    glucose_value: &str,
-) -> PathBuf {
-    let base_path = "icons/tray/";
-
-    // Parse the glucose_value string to f64
-    let parts: Vec<&str> = glucose_value.split_whitespace().collect();
-    let glucose_str = parts[0];
-    let glucose_f64 = match glucose_str.parse::<f64>() {
-        Ok(value) => value,
-        Err(_) => {
-            return app
-                .path_resolver()
-                .resolve_resource(format!("{}glucmon_icon_NOT-CONFIGURED.png", base_path))
-                .expect("failed to resolve resource")
-        }
-    };
-
-    let severity = match glucose_f64 {
-        v if v < 3.0 => "urgent",
-        v if v < 3.885 => "concern",
-        v if v < 10.0 => "normal",
-        v if v < 13.875 => "concern",
-        _ => "urgent",
-    };
-
-    let direction_str = match direction {
-        Direction::Flat => "flat",
-        Direction::FortyFiveUp => "1_up",     // "fortyfive_up",
-        Direction::FortyFiveDown => "1_down", // "fortyfive_down",
-        Direction::SingleUp => "1_up",
-        Direction::SingleDown => "1_down",
-        Direction::DoubleUp => "2_up",
-        Direction::DoubleDown => "2_down",
-        Direction::TripleUp => "3_up",
-        Direction::TripleDown => "3_down",
-        Direction::RateOutOfRange => {
-            return app
-                .path_resolver()
-                .resolve_resource(format!("{}glucmon_icon_NOT-WORKING.png", base_path))
-                .expect("failed to resolve resource")
-        }
-        Direction::NotComputable => {
-            return app
-                .path_resolver()
-                .resolve_resource(format!("{}glucmon_icon_NOT-WORKING.png", base_path))
-                .expect("failed to resolve resource")
-        }
-        Direction::None => {
-            return app
-                .path_resolver()
-                .resolve_resource(format!("{}glucmon_icon.png", base_path))
-                .expect("failed to resolve resource")
-        }
-    };
-
-    app.path_resolver()
-        .resolve_resource(format!(
-            "{}tray_{}_{}.png",
-            base_path, severity, direction_str
-        ))
-        .expect("failed to resolve resource")
-}
 fn main() {
     let tray_menu_glucose_data_item = CustomMenuItem::new(TRAY_MENU_ITEM_GLUCOSE_ENTRY, "--");
     let tray_menu_settings_item = CustomMenuItem::new(

--- a/src-tauri/src/utils/create_icon_from_path.rs
+++ b/src-tauri/src/utils/create_icon_from_path.rs
@@ -1,0 +1,19 @@
+use crate::error::Result;
+use std::path::PathBuf;
+use tauri::Icon;
+
+pub fn create_icon_from_path(path: &PathBuf) -> Result<Icon> {
+    let image = image::open(path)?.to_rgba8();
+    let (width, height) = image.dimensions();
+    let resized_image = image::imageops::resize(
+        &image,
+        width / 2,
+        height / 2,
+        image::imageops::FilterType::Nearest,
+    );
+    Ok(Icon::Rgba {
+        rgba: resized_image.into_vec(),
+        width: width / 2,
+        height: height / 2,
+    })
+}

--- a/src-tauri/src/utils/get_error_icon.rs
+++ b/src-tauri/src/utils/get_error_icon.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+use tauri::AppHandle;
+
+pub fn get_error_icon(app: &AppHandle) -> PathBuf {
+    app.path_resolver()
+        .resolve_resource("icons/tray/glucmon_icon_NOT-WORKING.png")
+        .unwrap()
+}

--- a/src-tauri/src/utils/get_icon_path_from_direction.rs
+++ b/src-tauri/src/utils/get_icon_path_from_direction.rs
@@ -1,4 +1,7 @@
-use crate::nightscout::Direction;
+use crate::{
+    error::{Error, Result},
+    nightscout::Direction,
+};
 use std::path::PathBuf;
 use tauri::AppHandle;
 
@@ -6,7 +9,7 @@ pub fn get_icon_path_from_direction(
     app: &AppHandle,
     direction: &Direction,
     glucose_value: &str,
-) -> PathBuf {
+) -> Result<PathBuf> {
     let base_path = "icons/tray/";
 
     // Parse the glucose_value string to f64
@@ -18,13 +21,13 @@ pub fn get_icon_path_from_direction(
             return app
                 .path_resolver()
                 .resolve_resource(format!("{}glucmon_icon_NOT-CONFIGURED.png", base_path))
-                .expect("failed to resolve resource")
+                .ok_or(Error::custom("Could not resolve resource. "))
         }
     };
 
     let severity = match glucose_f64 {
         v if v < 3.0 => "urgent",
-        v if v < 3.885 => "concern",
+        v if v < 4.0 => "concern",
         v if v < 10.0 => "normal",
         v if v < 13.875 => "concern",
         _ => "urgent",
@@ -44,19 +47,19 @@ pub fn get_icon_path_from_direction(
             return app
                 .path_resolver()
                 .resolve_resource(format!("{}glucmon_icon_NOT-WORKING.png", base_path))
-                .expect("failed to resolve resource")
+                .ok_or(Error::custom("Could not resolve resource."))
         }
         Direction::NotComputable => {
             return app
                 .path_resolver()
                 .resolve_resource(format!("{}glucmon_icon_NOT-WORKING.png", base_path))
-                .expect("failed to resolve resource")
+                .ok_or(Error::custom("Could not resolve resource."))
         }
         Direction::None => {
             return app
                 .path_resolver()
                 .resolve_resource(format!("{}glucmon_icon.png", base_path))
-                .expect("failed to resolve resource")
+                .ok_or(Error::custom("Could not resolve resource."))
         }
     };
 
@@ -65,5 +68,5 @@ pub fn get_icon_path_from_direction(
             "{}tray_{}_{}.png",
             base_path, severity, direction_str
         ))
-        .expect("failed to resolve resource")
+        .ok_or(Error::custom("Could not resolve resource."))
 }

--- a/src-tauri/src/utils/get_icon_path_from_direction.rs
+++ b/src-tauri/src/utils/get_icon_path_from_direction.rs
@@ -1,0 +1,69 @@
+use crate::nightscout::Direction;
+use std::path::PathBuf;
+use tauri::AppHandle;
+
+pub fn get_icon_path_from_direction(
+    app: &AppHandle,
+    direction: &Direction,
+    glucose_value: &str,
+) -> PathBuf {
+    let base_path = "icons/tray/";
+
+    // Parse the glucose_value string to f64
+    let parts: Vec<&str> = glucose_value.split_whitespace().collect();
+    let glucose_str = parts[0];
+    let glucose_f64 = match glucose_str.parse::<f64>() {
+        Ok(value) => value,
+        Err(_) => {
+            return app
+                .path_resolver()
+                .resolve_resource(format!("{}glucmon_icon_NOT-CONFIGURED.png", base_path))
+                .expect("failed to resolve resource")
+        }
+    };
+
+    let severity = match glucose_f64 {
+        v if v < 3.0 => "urgent",
+        v if v < 3.885 => "concern",
+        v if v < 10.0 => "normal",
+        v if v < 13.875 => "concern",
+        _ => "urgent",
+    };
+
+    let direction_str = match direction {
+        Direction::Flat => "flat",
+        Direction::FortyFiveUp => "1_up",     // "fortyfive_up",
+        Direction::FortyFiveDown => "1_down", // "fortyfive_down",
+        Direction::SingleUp => "1_up",
+        Direction::SingleDown => "1_down",
+        Direction::DoubleUp => "2_up",
+        Direction::DoubleDown => "2_down",
+        Direction::TripleUp => "3_up",
+        Direction::TripleDown => "3_down",
+        Direction::RateOutOfRange => {
+            return app
+                .path_resolver()
+                .resolve_resource(format!("{}glucmon_icon_NOT-WORKING.png", base_path))
+                .expect("failed to resolve resource")
+        }
+        Direction::NotComputable => {
+            return app
+                .path_resolver()
+                .resolve_resource(format!("{}glucmon_icon_NOT-WORKING.png", base_path))
+                .expect("failed to resolve resource")
+        }
+        Direction::None => {
+            return app
+                .path_resolver()
+                .resolve_resource(format!("{}glucmon_icon.png", base_path))
+                .expect("failed to resolve resource")
+        }
+    };
+
+    app.path_resolver()
+        .resolve_resource(format!(
+            "{}tray_{}_{}.png",
+            base_path, severity, direction_str
+        ))
+        .expect("failed to resolve resource")
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,5 +1,7 @@
 mod create_icon_from_path;
+mod get_error_icon;
 mod get_icon_path_from_direction;
 
 pub use create_icon_from_path::create_icon_from_path;
+pub use get_error_icon::get_error_icon;
 pub use get_icon_path_from_direction::get_icon_path_from_direction;

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,0 +1,5 @@
+mod create_icon_from_path;
+mod get_icon_path_from_direction;
+
+pub use create_icon_from_path::create_icon_from_path;
+pub use get_icon_path_from_direction::get_icon_path_from_direction;


### PR DESCRIPTION
This release allows error handling when reqwest does not achieve connection with nightscout. Can recover if it connects at a later time.